### PR TITLE
UDT: mass error 그래프 사이에 끼우기

### DIFF
--- a/mass_error.py
+++ b/mass_error.py
@@ -1,12 +1,19 @@
 import matplotlib.pyplot as plt
-# import spectrum_utils.plot as sup
-# import spectrum_plot as sup
 import mass_plot as mp
 import spectrum_utils.spectrum as sus
 
-def mass_error_plot(spectrum_top):
+def mass_error_plot(spectrum_top, spectrum_bottom):
     ## spectrum_utils 라이브러리(mp)의 mass_errors 함수 적용
-    fig, ax = plt.subplots(figsize=(10.5, 4))
-    mp.mass_errors(spectrum_top, plot_unknown=False, ax=ax)
+    fig = mp.facet(
+        spec_top=spectrum_top,
+        spec_mass_errors=spectrum_top,
+        spec_bottom=spectrum_bottom,
+        mass_errors_kws={"plot_unknown": False},
+        height=7,
+        width=10.5,
+    )   
+    
+    # fig, ax = plt.subplots(figsize=(10.5, 4))
+    # mp.mass_errors(spectrum_top, plot_unknown=False, ax=ax)
     plt.show()
     # plt.close()


### PR DESCRIPTION
mass_error.py만 고침 -> 두 그래프 사이에 mass error 그래프가 껴있도록 하는 전체적인 그래프창을 따로 띄우기